### PR TITLE
Allow copying events into the original base calendar.

### DIFF
--- a/run.rb
+++ b/run.rb
@@ -65,12 +65,12 @@ def new_calendar(name, time_zone)
   $service.insert_calendar(future_cal)
 end
 
-def copy_events(base_cal, new_cal, offset_days = 0)
+def copy_events(base_cal, destination_cal, offset_days = 0)
   return puts 'No events found' if base_cal.items.empty?
   base_cal.items.each do |event|
     new_start_time = event.start.date_time + offset_days
     new_end_time = event.end.date_time + offset_days
-    new_event(new_cal.id, event.summary, event.description, new_start_time.iso8601, new_end_time.iso8601, 'Asia/Hong_Kong')
+    new_event(destination_cal, event.summary, event.description, new_start_time.iso8601, new_end_time.iso8601, 'Asia/Hong_Kong')
   end
 end
 
@@ -79,14 +79,21 @@ $service = Google::Apis::CalendarV3::CalendarService.new
 $service.client_options.application_name = APPLICATION_NAME
 $service.authorization = authorize
 
-puts 'URL of base calendar'
-base_cal = $service.list_events(gets.chomp, single_events: true, order_by: 'startTime', time_min: '1970-01-01T00:00:00Z')
+puts 'ID of base calendar'
+base_cal_id = gets.chomp
+base_cal = $service.list_events(base_cal_id, single_events: true, order_by: 'startTime', time_min: '1970-01-01T00:00:00Z')
 
-puts 'Name of your new calendar'
-new_cal = new_calendar(gets, base_cal.time_zone)
+puts 'Name of your new calendar(blank to copy to source)'
+new_cal_name = gets.chomp
+if new_cal_name.length > 0
+  new_cal = new_calendar(new_cal_name, base_cal.time_zone)
+  destination_cal = new_cal.id
+else
+  destination_cal = base_cal_id
+end
 
 puts 'Set your offsets in days (default: 0)'
 days_of_offsets = gets
-copy_events(base_cal, new_cal, days_of_offsets.to_i)
+copy_events(base_cal, destination_cal, days_of_offsets.to_i)
 
 puts 'DONE!'


### PR DESCRIPTION
This PR allows leaving the new calendar name blank which causes the destination to be the same as the source. This is useful for me because I have some monthly and quarterly tasks that do not happen on precise intervals (needing to account for statutory holidays, vacations, etc...). This now lets me clone the events forwards and then manually adjust as necessary.

I've generally done this all by hand and a few browser tabs, but it's tedious and I've wanted to automate it for a while. This gets me a lot of the way there. Some more work will be needed to really be able to use it such as applying a filter on the events by date so that I don't wind up with exponential growth of events.